### PR TITLE
Added dependabot.yml for dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Fixes #3. Adds the [Dependabot](https://dependabot.com) to automatically update Gradle dependencies weekly through Github Actions [dependabot workflow file](https://github.com/wajahatkarim3/Imagine/blob/main/.github/dependabot.yml_. 